### PR TITLE
Update StackExchange Preprocessing.

### DIFF
--- a/stackexchange/preprocess_test.py
+++ b/stackexchange/preprocess_test.py
@@ -1,0 +1,59 @@
+"""Tests for stack exchange preprocessing.
+
+Note: We don't test for the cases where there are multiple accepted answer as
+it itsn't possible given how the accepted field if set based on a comparing the
+answer id to an int field of the question. If there was ever a case where both
+answers were accepted, the sort would be result in the being in the same order
+they were in originally.
+"""
+
+import random
+
+from preprocess import Answer, vote_sort
+
+
+def test_vote_sort_low_accepted_is_first():
+    # A should be first as it is accepted, even with a low score.
+    a = Answer(
+        authors=[], comments=[], score=100, accepted=True, date="", license="", text=""
+    )
+    b = Answer(
+        authors=[],
+        comments=[],
+        score=1000,
+        accepted=False,
+        date="",
+        license="",
+        text="",
+    )
+    assert vote_sort([b, a]) == [a, b]
+
+
+def test_vote_sort_high_accepted_is_first():
+    # B should be first as it is accepted and it has high scores
+    a = Answer(
+        authors=[], comments=[], score=100, accepted=False, date="", license="", text=""
+    )
+    b = Answer(
+        authors=[], comments=[], score=1000, accepted=True, date="", license="", text=""
+    )
+    assert vote_sort([b, a]) == [b, a]
+
+
+def test_vote_sort_no_accepted_is_ordered():
+    answers = [
+        Answer(
+            authors=[],
+            comments=[],
+            score=random.randint(10, 1000),
+            accepted=False,
+            date="",
+            license="",
+            text="",
+        )
+        for _ in range(random.randint(5, 10))
+    ]
+    prev_score = 100000
+    for answer in vote_sort(answers):
+        assert answer.score <= prev_score
+        prev_score = answer.score


### PR DESCRIPTION
This PR updates how stack exchange preprocessing can be done.

It adds two new flags, `--sort` lets you control how answers are added to the document. `--sort=time` orders the answers by the date they were first posted. `--sort=votes` orders the answers by the score they get, with the "accepted answer" being the first in the list.

This PR also adds a `--skip_comments` flag, which allows one to skip adding the comments to the generated document as stackexchange seems to consider comment ephemeral.

It also adds a new metadata field which is the set of all licenses that appear on the comments/answers/the question that go into a single document. Then comments/answers are posted way after the original question, the version of the CC license can change.

These changes are based on discussions from the last meeting.