### PR TITLE
Create a shared logging setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 .python-version
+**/licensed_pile_log.txt

--- a/licensed_pile/logs.py
+++ b/licensed_pile/logs.py
@@ -1,0 +1,72 @@
+"""Shared Logging setup for Licensed Pile."""
+
+import functools
+import logging
+import sys
+from typing import Protocol, Sequence
+
+from logging_json import JSONFormatter
+
+
+class GetFormatter(Protocol):
+    def __call__(self) -> logging.Formatter:
+        ...
+
+
+class GetHandler(Protocol):
+    def __call__(self) -> logging.Handler:
+        ...
+
+
+def get_json_formatter() -> logging.Formatter:
+    fields = {
+        "level_name": "levelname",
+        "timestamp": "asctime",
+        "module_name": "module",
+        "function_name": "funcName",
+        "logger": "name",
+    }
+    return JSONFormatter(fields=fields)
+
+
+def get_stream_handler() -> logging.Handler:
+    stream_handler = logging.StreamHandler(stream=sys.stdout)
+    return stream_handler
+
+
+def get_file_handler(log_file: str) -> logging.Handler:
+    file_handler = logging.FileHandler(log_file)
+    return file_handler
+
+
+# TODO: Add logging formatters that go to centralized places like
+# datadog or watch tower.
+DEFAULT_HANDLERS = (
+    get_stream_handler,
+    functools.partial(get_file_handler, log_file="licensed_pile_log.txt"),
+)
+
+
+def configure_logging(
+    name: str = "licensed-pile",
+    level: str = "INFO",
+    get_formatter_fn: GetFormatter = get_json_formatter,
+    handler_fns: Sequence[GetHandler] = DEFAULT_HANDLERS,
+) -> logging.Logger:
+    logger = logging.getLogger(name)
+    level = getattr(logging, level.upper(), logging.INFO)
+    logger.setLevel(level)
+
+    formatter = get_formatter_fn()
+
+    for handler_fn in handler_fns:
+        handler = handler_fn()
+        handler.setLevel(level)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    return logger
+
+
+def get_logger(name: str = "licensed-pile") -> logging.Logger:
+    return logging.getLogger(name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ dolma
 smart_open
 markdown-it-py
 charset_normalizer
+logging_json

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,5 @@ setup(
     packages=find_packages(),
     python_requires=">=3.8",
     license="MIT",
-    install_requires=[],
+    install_requires=["logging_json"],
 )

--- a/ubuntu/preprocess.py
+++ b/ubuntu/preprocess.py
@@ -7,7 +7,14 @@ import os
 import re
 from tempfile import TemporaryDirectory
 
+from licensed_pile.logs import configure_logging
 from licensed_pile.write import ShardParallelProcessor
+
+# By configuring the logger as a module level logger with the name
+# dolma.ProcessorClassName, our logger configuration is used (although dolma
+# forces a WARN level). The other option is to override `cls.get_logger` to
+# set it up yourself (allowing you to do things like use a lower log level.)
+configure_logging("dolma.UbuntuChatParallel")
 
 parser = argparse.ArgumentParser(
     description="Preprocess raw chats in the dolma format."

--- a/ubuntu/to-dolma.py
+++ b/ubuntu/to-dolma.py
@@ -9,6 +9,7 @@ import urllib.parse
 from charset_normalizer import from_bytes
 
 from licensed_pile.licenses import PermissiveLicenses
+from licensed_pile.logs import configure_logging, get_logger
 from licensed_pile.write import to_dolma
 
 SOURCE_NAME = "ubuntu-chat"
@@ -37,6 +38,8 @@ def format_dolma(chat: str, source_name: str = SOURCE_NAME, base_url: str = BASE
     # Manually split because os.path.split only give (head, tail)
     *_, year, month, day, channel = os.path.splitext(chat)[0].split(os.path.sep)
     created = datetime.date(int(year), int(month), int(day))
+    logger = get_logger()
+    logger.debug("Reading chat log from %s", chat)
     with open(chat, "rb") as f:
         # There is some encoding weirdness that this seems to fix.
         text = str(from_bytes(f.read()).best())
@@ -61,6 +64,13 @@ def format_dolma(chat: str, source_name: str = SOURCE_NAME, base_url: str = BASE
 
 
 def main(args):
+    l = configure_logging()
+    l.info(
+        "Converting Chats from %s to the dolma format (at %s%s)",
+        args.data,
+        args.output_dir,
+        args.filename,
+    )
     # Use iterators so we don't have to load the whole dataset in memory.
     #                                                    year  month day   channel
     chats = map(


### PR DESCRIPTION
The main approach is to call `licensed_pile.logs.configure_logging` in the main function for your script. The default logger name is `licensed-pile`. Then you can use `licensed_pile.get_logger` to get the logger (they are singletons based on name). You can also use `logging.getLogger("licensed-pile")`. Then you can call things like `.info` or `.debug`.

For parallel processing, the configure call should be at the module level and the logger name should be `dolma.ParallelProcessorName`. The other option is to override `cls.get_logger` to have more control over the logger.